### PR TITLE
fix: session이 발급되지 않는 문제 해결.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ replay_pid*
 *.jar
 *.war
 *.ear
+httptest
 
 !gradlew
 !gradlew.bat

--- a/src/main/java/park/bumsiku/config/Security.java
+++ b/src/main/java/park/bumsiku/config/Security.java
@@ -43,6 +43,7 @@ public class Security {
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
                 )
+                .formLogin(AbstractHttpConfigurer::disable)
                 // 3) 세션 정책 · 동시성 제어 · 세션 고정 공격 방지
                 .sessionManagement(session -> session
                         // 세션 생성 정책
@@ -67,6 +68,7 @@ public class Security {
                         .invalidateHttpSession(true)
                         .deleteCookies("JSESSIONID")
                 );
+
 
         return http.build();
     }

--- a/src/test/java/park/bumsiku/integration/AuthTest.java
+++ b/src/test/java/park/bumsiku/integration/AuthTest.java
@@ -6,6 +6,7 @@ import park.bumsiku.config.AbstractTestSupport;
 import park.bumsiku.domain.dto.request.LoginRequest;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class AuthTest extends AbstractTestSupport {
@@ -18,11 +19,13 @@ public class AuthTest extends AbstractTestSupport {
                 .password("password")
                 .build();
 
-        // Perform login request and expect 200 OK
+        // Perform login request and expect 200 OK with secure cookie
         mockMvc.perform(post("/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("JSESSIONID"))
+                .andExpect(cookie().secure("JSESSIONID", true));
     }
 
     @Test


### PR DESCRIPTION
## 🔒 Fix: API 기반 세션 인증 로직 오류 수정

### 📌 변경사항 요약

- Spring Security의 `formLogin()` 기능을 비활성화하고, **직접 구현한 로그인 컨트롤러**에서 세션 기반 인증을 완전히 처리하도록 리팩토링
- 인증 성공 시 `SecurityContext`를 `HttpSession`에 명시적으로 저장하여 이후 요청에서 인증 상태가 유지되도록 함
- 로컬 개발을 위한 `Secure=false` 설정을 제거하고, **컨테이너가 자동으로 세션 쿠키를 발급하도록 개선**

---

### ✅ 주요 수정 내용

- `LoginController` 내 로그인 성공 처리 로직 변경:
  - `AuthenticationManager`를 통해 인증 성공 시, `SecurityContextHolder`에 설정
  - `HttpSession`을 수동 생성하고, 세션에 `SPRING_SECURITY_CONTEXT` 키로 `SecurityContext`를 저장
  - **직접 쿠키를 수동 생성하지 않고**, 컨테이너가 자동으로 `Set-Cookie: JSESSIONID` 헤더를 내려주도록 변경

- `SecurityConfig` 유지:
  - `formLogin()` 비활성화 유지 (`AbstractHttpConfigurer::disable`)
  - `sessionManagement()` 정책은 `IF_REQUIRED`로 설정되어 있으므로, 컨트롤러에서 `request.getSession(true)` 호출 시 정상적으로 세션 생성 가능

---

### 🧪 테스트 시나리오

1. `POST /login` 요청 (JSON 바디)
   - 로그인 성공 시 `Set-Cookie: JSESSIONID=...` 응답 확인
2. 이후 `Cookie: JSESSIONID=...` 를 포함하여 인증이 필요한 엔드포인트(`/admin/**`) 호출
   - 인증 상태 유지 및 `200 OK` 응답 확인

---

### 📎 참고

- 기존에는 `SecurityContextHolder`에만 인증 정보를 올려두었기 때문에, 이후 요청에서 인증 상태가 유지되지 않음
- 이슈 해결을 위해 `HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY` 사용하여 세션에 명시적으로 인증 컨텍스트 저장 필요