### PR TITLE
로그인 문제 해결, 카테고리id 응답에 포함

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -122,8 +122,9 @@ jobs:
               -e SPRING_JPA_SHOW_SQL=true \
               -e SPRING_JPA_DATABASE_PLATFORM=org.hibernate.dialect.MySQL8Dialect \
               -e ADMIN_PASSWORD="${{ secrets.ADMIN_PASSWORD }}" \
-              -e SERVER_SERVLET_SESSION_TIMEOUT=1h \
+              -e SERVER_SERVLET_SESSION_TIMEOUT=2h \
               -e SERVER_SERVLET_SESSION_COOKIE_SECURE=true \
+              -e SERVER_SERVLET_SESSION_COOKIE_SAME_SITE=None \
               -e SPRINGDOC_PACKAGES_TO_SCAN=park.bumsiku.controller \
               -e SPRINGDOC_API_INFO_TITLE="Bumsiku Blog API" \
               -e SPRINGDOC_API_INFO_VERSION=v1.0.0 \

--- a/src/main/java/park/bumsiku/controller/LoginController.java
+++ b/src/main/java/park/bumsiku/controller/LoginController.java
@@ -16,6 +16,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -74,6 +75,27 @@ public class LoginController {
             return ResponseEntity.ok().build();
         } catch (Exception e) {
             log.warn("Login failed for user: {}", loginRequest.getUsername(), e);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+    }
+
+    @Operation(
+            summary = "세션 상태 확인",
+            description = "현재 세션이 유효한지 확인합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "세션이 유효함"),
+                    @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음", content = @Content)
+            }
+    )
+    @GetMapping("/session")
+    public ResponseEntity<Void> checkSession(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session != null && session.getAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY) != null) {
+            log.info("Session is valid with ID: {}", session.getId());
+            return ResponseEntity.ok().build();
+        } else {
+            log.info("Session is invalid or expired");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
     }

--- a/src/main/java/park/bumsiku/domain/dto/response/PostResponse.java
+++ b/src/main/java/park/bumsiku/domain/dto/response/PostResponse.java
@@ -13,6 +13,7 @@ public class PostResponse {
     private int id;
     private String title;
     private String content;
+    private int categoryId;
     private String createdAt;
     private String updatedAt;
 }


### PR DESCRIPTION
fix: 로그인 문제 해결

- cross site에서도 쿠키가 저장
- /session api를 만들어서 세션이 유효한지 확인하도록 수정

feat: PostResponse에 category_id 필드를 추가