### PR TITLE
예외 처리 로직 개선

### DIFF
--- a/src/main/java/park/bumsiku/utils/GlobalExceptionHandler.java
+++ b/src/main/java/park/bumsiku/utils/GlobalExceptionHandler.java
@@ -27,56 +27,40 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Response<Void>> handleConstraintViolationException(IllegalArgumentException e) {
         log.warn("Invalid argument: {}", e.getMessage());
-        Response<Void> response = Response.error(
-                400,
-                e.getMessage() != null ? e.getMessage() : "Invalid Argument"
-        );
+        Response<Void> response = Response.error(HttpStatus.BAD_REQUEST.value(), e.getMessage() != null ? e.getMessage() : "Invalid Argument");
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<Response<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         log.warn("Invalid request body: {}", e.getMessage());
-        Response<Void> response = Response.error(
-                400,
-                "Invalid request body"
-        );
+        Response<Void> response = Response.error(HttpStatus.BAD_REQUEST.value(), "Invalid request body");
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<Response<Void>> handleConstraintViolationException(ConstraintViolationException e) {
         log.warn("Validation error: {}", e.getMessage());
-        Response<Void> response = Response.error(
-                400,
-                e.getMessage() != null ? e.getMessage() : "유효성 검증 오류"
-        );
+        Response<Void> response = Response.error(HttpStatus.BAD_REQUEST.value(), e.getMessage() != null ? e.getMessage() : "유효성 검증 오류");
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<Response<Void>> handleNoSuchArgumentException(NoSuchElementException e) {
         log.warn("Resource not found: {}", e.getMessage());
-        Response<Void> response = Response.error(
-                404,
-                e.getMessage() != null ? e.getMessage() : "Argument not found"
-        );
+        Response<Void> response = Response.error(HttpStatus.NOT_FOUND.value(), e.getMessage() != null ? e.getMessage() : "Argument not found");
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<Response<Void>> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
-        // 잘못 전달된 파라미터 이름, 타입, 값 정보를 조합해서 메시지를 구성
         String param = e.getName();
-        String expectedType = e.getRequiredType() != null
-                ? e.getRequiredType().getSimpleName()
-                : "unknown";
+        String expectedType = e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown";
         Object value = e.getValue();
-        String detail = String.format("Parameter '%s' must be of type '%s' but value '%s' is invalid",
-                param, expectedType, value);
+        String detail = String.format("Parameter '%s' must be of type '%s' but value '%s' is invalid", param, expectedType, value);
 
         log.warn("Type mismatch error: {}", detail);
-        Response<Void> response = Response.error(400, detail);
+        Response<Void> response = Response.error(HttpStatus.BAD_REQUEST.value(), detail);
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
@@ -106,10 +90,7 @@ public class GlobalExceptionHandler {
         String requestTrace = "Request: " + Thread.currentThread().getName();
         log.error("Unhandled exception occurred: {}\n{}", e.getMessage(), partialTrace);
         discord.sendMessage("Unhandled exception occurred: " + e.getMessage() + "\n" + partialTrace + "\n" + requestTrace);
-        Response<Void> response = Response.error(
-                500,
-                "Internal Server Error"
-        );
+        Response<Void> response = Response.error(500, "Internal Server Error");
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/park/bumsiku/utils/GlobalExceptionHandler.java
+++ b/src/main/java/park/bumsiku/utils/GlobalExceptionHandler.java
@@ -31,10 +31,10 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, status);
     }
 
-    private ResponseEntity<Response<Void>> handleErrorException(String logMessage, Exception e, String logDetails, HttpStatus status, String errorMessage) {
-        log.error(logMessage, e.getMessage(), logDetails);
-        Response<Void> response = Response.error(status.value(), errorMessage);
-        return new ResponseEntity<>(response, status);
+    private ResponseEntity<Response<Void>> handleErrorException(Exception e, String logDetails) {
+        log.error("Unhandled exception occurred: {}\n{}", e.getMessage(), logDetails);
+        Response<Void> response = Response.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Internal Server Error");
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
@@ -80,7 +80,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Response<Void>> handleUnhandledException(Exception e) {
         StackTraceElement[] stackTrace = e.getStackTrace();
-        int maxLines = Math.min(2, stackTrace.length); // Reduced to 2 lines max
+        int maxLines = Math.min(2, stackTrace.length);
         StringBuilder partialTrace = new StringBuilder();
         partialTrace.append(e).append("\n");
         for (int i = 0; i < maxLines; i++) {
@@ -90,6 +90,6 @@ public class GlobalExceptionHandler {
 
         discord.sendMessage("Unhandled exception occurred: " + e.getMessage() + "\n" + partialTrace + "\n" + requestTrace);
 
-        return handleErrorException("Unhandled exception occurred: {}\n{}", e, partialTrace.toString(), HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error");
+        return handleErrorException(e, partialTrace.toString());
     }
 }


### PR DESCRIPTION
## 변경사항

- 크롤링 봇 또는 취약점 탐지기의 랜덤 접근을 차단하도록 별도의 4xx 응답 로직을 작성
- `GlobalExceptionHandler`에 존재하던 중복 로직 (log 작성 -> 응답 생성 -> 응답 반환)을 메서드로 분리하여 한 곳에서 관리
- 하드코딩되어있던 응답 코드를 HttpStatus 내부에 정의된 상수로 변경하여 코드 가독성 향상