### PR TITLE
로그 저장소로 Loki 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'com.sksamuel.scrimage:scrimage-webp:4.3.1'
     implementation 'software.amazon.awssdk:s3:2.31.35'
     implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
+    implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
     implementation 'com.oracle.database.jdbc:ojdbc10:19.27.0.0'
     implementation 'com.oracle.database.security:oraclepki:23.8.0.25.04'
     implementation 'com.oracle.database.security:osdt_core:21.18.0.0'

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -20,28 +20,43 @@
     </appender>
 
     <springProfile name="prod">
-        <appender name="LOGSTASH_TCP" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-            <destination>${ELK_HOST}:${ELK_PORT}</destination>
-            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-                <includeMdc>true</includeMdc>
-                <includeContext>true</includeContext>
-                <customFields>
-                    {"application":"blog-server","environment":"${spring.profiles.active:-local}","server":"${server.address:-localhost}"}
-                </customFields>
-                <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSS</timestampPattern>
-            </encoder>
-            <reconnectionDelay>10 seconds</reconnectionDelay>
-            <writeTimeout>10 seconds</writeTimeout>
-            <includeCallerData>false</includeCallerData>
+        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+            <http>
+                <url>${loki.url:-${LOKI_URL:-http://localhost:3100/loki/api/v1/push}}</url>
+                <connectTimeoutMs>5000</connectTimeoutMs>
+                <readTimeoutMs>10000</readTimeoutMs>
+            </http>
+            <format>
+                <label>
+                    <pattern>
+                        app=blog-server,env=${spring.profiles.active:-local},level=%level,logger=%logger{20},host=${HOSTNAME:-localhost}
+                    </pattern>
+                </label>
+                <message>
+                    <pattern>%msg</pattern>
+                </message>
+                <exception>
+                    <pattern>%ex</pattern>
+                </exception>
+            </format>
+            <batch>
+                <bufferSize>512</bufferSize>
+                <timeoutMs>2000</timeoutMs>
+            </batch>
         </appender>
 
-        <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
-            <appender-ref ref="LOGSTASH_TCP"/>
+        <appender name="ASYNC_LOKI" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="LOKI"/>
             <queueSize>1024</queueSize>
             <discardingThreshold>0</discardingThreshold>
             <includeCallerData>false</includeCallerData>
             <neverBlock>true</neverBlock>
         </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE_JSON"/>
+            <appender-ref ref="ASYNC_LOKI"/>
+        </root>
     </springProfile>
 
     <!-- Profiles -->
@@ -54,7 +69,7 @@
     <springProfile name="prod">
         <root level="INFO">
             <appender-ref ref="CONSOLE_JSON"/>
-            <appender-ref ref="ASYNC_LOGSTASH"/>
+            <appender-ref ref="ASYNC_LOKI"/>
         </root>
     </springProfile>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -29,7 +29,7 @@
             <format>
                 <label>
                     <pattern>
-                        app=blog-server,env=${spring.profiles.active:-local},level=%level,logger=%logger{20},host=${HOSTNAME:-localhost}
+                        app=blog-server,env=${spring.profiles.active:-local},level=%level,logger=%logger{20},host=${HOSTNAME:-localhost},requestId=%X{requestId}
                     </pattern>
                 </label>
                 <message>


### PR DESCRIPTION
## 변경

기존 ELK Stack의 무거움과 복잡함에서 벗어나서 Grafana로 추적하기 쉽도록 Loki를 저장소로 사용합니다.

원래 Prometheus 대시보드로 Grafana를 사용하고 있었기에 아키텍쳐의 큰 변동사항은 없습니다.

<img width="1094" height="445" alt="image" src="https://github.com/user-attachments/assets/531ca78b-1145-41cb-b14b-758851d00afd" />
